### PR TITLE
Fix issue when io.Reader returns a partial read

### DIFF
--- a/unpacker.go
+++ b/unpacker.go
@@ -1,7 +1,6 @@
 package binpacker
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -52,33 +51,9 @@ func (u *Unpacker) FetchByte(b *byte) *Unpacker {
 // ShiftBytes fetch n bytes in io.Reader. Returns a byte array and an error if
 // exists.
 func (u *Unpacker) ShiftBytes(_n uint64) ([]byte, error) {
-	var buffer bytes.Buffer
-	n := int(_n)
-	size := 32 * 1024
-	var buf []byte
-	var rn = 0
-	var err error
-	for {
-		if n == 0 {
-			break
-		} else if n < size {
-			buf = make([]byte, n)
-		} else {
-			buf = make([]byte, size)
-		}
-		rn, err = u.reader.Read(buf)
-		n -= rn
-		if rn > 0 {
-			buffer.Write(buf)
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			break
-		}
-	}
-	return buffer.Bytes(), err
+	buf := make([]byte, _n)
+	_, err := io.ReadFull(u.reader, buf)
+	return buf, err
 }
 
 // FetchBytes read n bytes and set to bytes.


### PR DESCRIPTION
First of all, thanks for great open source project. We use binpacker to unpack length prefixed data sent over network (using ``BytesWithUint32Prefix``). 

We found our data corrupted when we would be unpacking longer messages. It turned out to be an issue when ``io.Reader`` would return a partial read. The issue was caused here: ``buffer.Write(buf)``. If a read was smaller than allocated ``buf``, data would be padded with a bunch of 0s at the end and all of it written to the final output buffer. The issue can be solved with a change to ``buffer.Write(buf[:rn])`` but after I examined the method I thought it was better to leverage golang standard library instead. The ``bytes.Buffer`` usage was unnecessary since we know the final size in advance and we read it all anyway.

Let me know if you see any issues and I'll be happy to tweak this PR.