### PR TITLE
User must provide the byte order explicitly. Close #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ go get github.com/zhuangsirui/binpacker
 
 ```go
 buffer := new(bytes.Buffer)
-packer := binpacker.NewPacker(buffer)
+packer := binpacker.NewPacker(binary.BigEndian, buffer)
 packer.PushByte(0x01)
 packer.PushBytes([]byte{0x02, 0x03})
 packer.PushUint16(math.MaxUint16)
@@ -22,7 +22,7 @@ packer.PushUint16(math.MaxUint16)
 ```go
 // You can push data like this
 buffer := new(bytes.Buffer)
-packer := binpacker.NewPacker(buffer)
+packer := binpacker.NewPacker(binary.BigEndian, buffer)
 packer.PushByte(0x01).PushBytes([]byte{0x02, 0x03}).PushUint16(math.MaxUint16)
 packer.Error() // Make sure error is nil
 ```
@@ -33,8 +33,8 @@ packer.Error() // Make sure error is nil
 
 ```go
 buffer := new(bytes.Buffer)
-packer := binpacker.NewPacker(buffer)
-unpacker := binpacker.NewUnpacker(buffer)
+packer := binpacker.NewPacker(binary.BigEndian, buffer)
+unpacker := binpacker.NewUnpacker(binary.BigEndian, buffer)
 packer.PushByte(0x01)
 packer.PushUint16(math.MaxUint16)
 ```

--- a/packer.go
+++ b/packer.go
@@ -13,17 +13,12 @@ type Packer struct {
 	err    error
 }
 
-// NewPacker returns a *Packer hold an io.Writer.
-func NewPacker(writer io.Writer) *Packer {
+// NewPacker returns a *Packer hold an io.Writer. User must provide the byte order explicitly.
+func NewPacker(endian binary.ByteOrder, writer io.Writer) *Packer {
 	return &Packer{
 		writer: writer,
-		endian: binary.BigEndian,
+		endian: endian,
 	}
-}
-
-// SetByteOrder can set BigEndian or LittleEndian for packer
-func (p *Packer) SetByteOrder(byteOrder binary.ByteOrder) {
-	p.endian = byteOrder
 }
 
 // Error returns an error if any errors exists

--- a/packer_test.go
+++ b/packer_test.go
@@ -7,11 +7,12 @@ import (
 	"math"
 
 	"github.com/stretchr/testify/assert"
+	"encoding/binary"
 )
 
 func TestPushByte(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushByte(0x01)
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{1}, "byte error.")
@@ -19,7 +20,7 @@ func TestPushByte(t *testing.T) {
 
 func TestPushBytes(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushBytes([]byte{0x01, 0x002})
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{0x01, 0x02}, "bytes error.")
@@ -27,7 +28,7 @@ func TestPushBytes(t *testing.T) {
 
 func TestPushUint8(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushUint8(1)
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{1}, "uint8 error.")
@@ -35,7 +36,7 @@ func TestPushUint8(t *testing.T) {
 
 func TestPushUint16(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushUint16(1)
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{0, 1}, "uint16 error.")
@@ -43,7 +44,7 @@ func TestPushUint16(t *testing.T) {
 
 func TestPushInt16(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushInt16(-1)
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{255, 255}, "uint16 error.") // -1 eq 255 255
@@ -51,7 +52,7 @@ func TestPushInt16(t *testing.T) {
 
 func TestPushUint32(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushUint32(1)
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{0, 0, 0, 1}, "uint32 error.")
@@ -59,7 +60,7 @@ func TestPushUint32(t *testing.T) {
 
 func TestPushInt32(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushInt32(-1)
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{255, 255, 255, 255}, "int32 error.")
@@ -67,7 +68,7 @@ func TestPushInt32(t *testing.T) {
 
 func TestPushUint64(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushUint64(1)
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{0, 0, 0, 0, 0, 0, 0, 1}, "uint64 error.")
@@ -75,7 +76,7 @@ func TestPushUint64(t *testing.T) {
 
 func TestPushInt64(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushInt64(-1)
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{255, 255, 255, 255, 255, 255, 255, 255}, "int64 error.")
@@ -83,7 +84,7 @@ func TestPushInt64(t *testing.T) {
 
 func TestPushFloat32(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushFloat32(math.SmallestNonzeroFloat32)
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{0, 0, 0, 1}, "float32 error.")
@@ -91,7 +92,7 @@ func TestPushFloat32(t *testing.T) {
 
 func TestPushFloat64(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushFloat64(math.SmallestNonzeroFloat64)
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{0, 0, 0, 0, 0, 0, 0, 1}, "float64 error.")
@@ -99,7 +100,7 @@ func TestPushFloat64(t *testing.T) {
 
 func TestPushString(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushString("Hi")
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{'H', 'i'}, "string error.")
@@ -107,7 +108,7 @@ func TestPushString(t *testing.T) {
 
 func TestCombinedPush(t *testing.T) {
 	b := new(bytes.Buffer)
-	p := NewPacker(b)
+	p := NewPacker(binary.BigEndian, b)
 	p.PushUint16(1).PushString("Hi")
 	assert.Equal(t, p.Error(), nil, "Has error.")
 	assert.Equal(t, b.Bytes(), []byte{0, 1, 'H', 'i'}, "combine push error.")

--- a/unpacker.go
+++ b/unpacker.go
@@ -15,17 +15,12 @@ type Unpacker struct {
 	err    error
 }
 
-// NewUnpacker returns a *Unpacker which hold an io.Reader.
-func NewUnpacker(reader io.Reader) *Unpacker {
+// NewUnpacker returns a *Unpacker which hold an io.Reader. User must provide the byte order explicitly.
+func NewUnpacker(endian binary.ByteOrder, reader io.Reader) *Unpacker {
 	return &Unpacker{
 		reader: reader,
-		endian: binary.BigEndian,
+		endian: endian,
 	}
-}
-
-// SetByteOrder can set BigEndian or LittleEndian for unpacker
-func (p *Unpacker) SetByteOrder(byteOrder binary.ByteOrder) {
-	p.endian = byteOrder
 }
 
 // Error returns an error if any errors exists

--- a/unpacker_test.go
+++ b/unpacker_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 
 	"github.com/stretchr/testify/assert"
+	"encoding/binary"
 )
 
 // TestReader wraps a []byte and returns reads of a specific length.
@@ -35,8 +36,8 @@ func (t *testReader) Read(buf []byte) (n int, err error) {
 
 func TestShiftByte(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushByte(0x01)
 	b, err := u.ShiftByte()
 	assert.Equal(t, err, nil, "Has error.")
@@ -49,7 +50,7 @@ func TestShiftBytes(t *testing.T) {
 		stride: 2,
 	}
 
-	u := NewUnpacker(reader)
+	u := NewUnpacker(binary.BigEndian, reader)
 	bs, err := u.ShiftBytes(5)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte{0x01, 0x02, 0x03, 0x04, 0x05}, bs, "byte error.")
@@ -57,8 +58,8 @@ func TestShiftBytes(t *testing.T) {
 
 func TestShiftUint8(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushUint8(1)
 	i, err := u.ShiftUint8()
 	assert.Equal(t, err, nil, "Has error.")
@@ -67,8 +68,8 @@ func TestShiftUint8(t *testing.T) {
 
 func TestShiftUint16(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushUint16(1)
 	i, err := u.ShiftUint16()
 	assert.Equal(t, err, nil, "Has error.")
@@ -77,8 +78,8 @@ func TestShiftUint16(t *testing.T) {
 
 func TestShiftInt16(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushInt16(-1)
 	i, err := u.ShiftInt16()
 	assert.Equal(t, err, nil, "Has error.")
@@ -87,8 +88,8 @@ func TestShiftInt16(t *testing.T) {
 
 func TestShiftUint32(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushUint32(1)
 	i, err := u.ShiftUint32()
 	assert.Equal(t, err, nil, "Has error.")
@@ -97,8 +98,8 @@ func TestShiftUint32(t *testing.T) {
 
 func TestShiftInt32(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushInt32(-1)
 	i, err := u.ShiftInt32()
 	assert.Equal(t, err, nil, "Has error.")
@@ -107,8 +108,8 @@ func TestShiftInt32(t *testing.T) {
 
 func TestShiftUint64(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushUint64(1)
 	i, err := u.ShiftUint64()
 	assert.Equal(t, err, nil, "Has error.")
@@ -117,8 +118,8 @@ func TestShiftUint64(t *testing.T) {
 
 func TestShiftFloat32(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushFloat32(math.SmallestNonzeroFloat32)
 	i, err := u.ShiftFloat32()
 	assert.Equal(t, err, nil, "Has error.")
@@ -131,8 +132,8 @@ func TestShiftFloat32(t *testing.T) {
 
 func TestShiftFloat64(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushFloat64(math.SmallestNonzeroFloat64)
 	i, err := u.ShiftFloat64()
 	assert.Equal(t, err, nil, "Has error.")
@@ -141,8 +142,8 @@ func TestShiftFloat64(t *testing.T) {
 
 func TestFetchFloat32(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushFloat32(math.SmallestNonzeroFloat32)
 	var f float32
 	u.FetchFloat32(&f)
@@ -151,8 +152,8 @@ func TestFetchFloat32(t *testing.T) {
 
 func TestFetchFloat64(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushFloat64(math.SmallestNonzeroFloat64)
 	var f float64
 	u.FetchFloat64(&f)
@@ -161,8 +162,8 @@ func TestFetchFloat64(t *testing.T) {
 
 func TestShiftInt64(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushInt64(-1)
 	i, err := u.ShiftInt64()
 	assert.Equal(t, err, nil, "Has error.")
@@ -171,8 +172,8 @@ func TestShiftInt64(t *testing.T) {
 
 func TestShiftString(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushString("Hi")
 	s, err := u.ShiftString(2)
 	assert.Equal(t, err, nil, "Has error.")
@@ -181,8 +182,8 @@ func TestShiftString(t *testing.T) {
 
 func TestRead(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	p.PushByte(0x01)
 	p.PushBytes([]byte("Hi"))
 	p.PushUint8(1)
@@ -229,8 +230,8 @@ func TestRead(t *testing.T) {
 
 func TestReadWithPerfix(t *testing.T) {
 	buf := new(bytes.Buffer)
-	p := NewPacker(buf)
-	u := NewUnpacker(buf)
+	p := NewPacker(binary.BigEndian, buf)
+	u := NewUnpacker(binary.BigEndian, buf)
 	var bs []byte
 	var s string
 


### PR DESCRIPTION
User must provide the byte order explicitly. 